### PR TITLE
[cmake] Include Boost header directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(YARP REQUIRED)
 include_directories(
     ${Eigen_INCLUDE_DIRS}
     ${EigenLgsm_INCLUDE_DIRS}
+    ${Boost_INCLUDE_DIRS}
 )
 
 add_subdirectory(ocra)


### PR DESCRIPTION
Necessary for the library to work on OS X. 

They will probably be then other issues (related to clang support) 
and the fact that the Boost Include Directories are not properly exported 
in the `***Config.CMake` files, but this is a first step. 

See failing Travis build at https://travis-ci.org/robotology/codyco-superbuild/jobs/97542016 .
